### PR TITLE
fix: surface failed action invocations instead of closing silently

### DIFF
--- a/palette.sh
+++ b/palette.sh
@@ -55,9 +55,45 @@ choice="$(
 
 action_id="${choice%%$'\t'*}"
 
-# Invoke. Capture output so a failure is visible before the overlay closes;
-# on success, just exit and let the overlay disappear.
-if ! out="$("$herdr_bin" plugin action invoke "$action_id" 2>&1)"; then
+# Invoke the action. `herdr plugin action invoke` is fire-and-forget: it returns
+# as soon as the action is DISPATCHED, so a zero exit only means "accepted" — the
+# action's command can still fail afterwards (e.g. a moved/missing script exits
+# 127). The response carries the dispatched run's log_id; we poll the plugin log
+# until it reaches a terminal state so a failed action surfaces its error instead
+# of the overlay vanishing on a silent no-op.
+resp="$("$herdr_bin" plugin action invoke "$action_id" 2>&1)"
+if [ $? -ne 0 ]; then
   die "command-palette: failed to invoke ${action_id}
-${out}"
+${resp}"
 fi
+
+# Pull the run's log_id and owning plugin straight from the invoke response (the
+# plugin_id is taken from the response rather than split off the action_id, which
+# can itself contain dots, e.g. jt.command-palette). If the response isn't the
+# shape we expect (older herdr), skip polling and exit cleanly — never make a
+# working invoke look broken.
+log_id="$(printf '%s' "$resp" | jq -r '.result.log.log_id // empty' 2>/dev/null)"
+plugin_id="$(printf '%s' "$resp" | jq -r '.result.log.plugin_id // empty' 2>/dev/null)"
+[ -n "$log_id" ] && [ -n "$plugin_id" ] || exit 0
+
+# Poll that run's log entry until it finishes (or we hit the deadline). Most
+# actions complete in well under a second; one still "running" at the deadline is
+# assumed to be a healthy long-running action and left alone.
+i=0
+while [ "$i" -lt 25 ]; do  # ~5s at 0.2s/iteration
+  i=$((i + 1))
+  entry="$(
+    "$herdr_bin" plugin log list --plugin "$plugin_id" --limit 20 2>/dev/null \
+      | jq -c --arg id "$log_id" '.result.logs[]? | select(.log_id == $id)' 2>/dev/null
+  )"
+  case "$(printf '%s' "$entry" | jq -r '.status // empty' 2>/dev/null)" in
+    succeeded) exit 0 ;;
+    failed)
+      code="$(printf '%s' "$entry" | jq -r '.exit_code // "?"' 2>/dev/null)"
+      err="$(printf '%s' "$entry" | jq -r '.stderr // empty' 2>/dev/null)"
+      die "command-palette: ${action_id} failed (exit ${code})
+${err}"
+      ;;
+  esac
+  sleep 0.2
+done


### PR DESCRIPTION
## Problem

`herdr plugin action invoke` is **fire-and-forget**: it returns success the moment the action is *dispatched*, not when the action's command finishes. So when the picked action's command fails afterwards — e.g. a plugin whose scripts were moved, so `bash open.sh` exits `127 (No such file or directory)` — `palette.sh` saw the invoke exit `0`, showed nothing, and the overlay closed.

From the user's side this is indistinguishable from "I pressed enter and nothing happened": the palette appears to do nothing, even though the real failure is recorded server-side in the plugin log.

## Change

`palette.sh` now confirms the action actually ran:

- Read the dispatched run's `log_id` and owning `plugin_id` straight from the invoke response (taken from the response rather than split off the action id, which can itself contain dots, e.g. `jt.command-palette`).
- Poll `herdr plugin log list` for that `log_id` until it reaches a terminal state.
- On `failed`, report the action's exit code and `stderr` via the existing `die()` so the error is visible before the overlay closes.
- Bounded ~5s deadline: a still-running action at the deadline is treated as a healthy long-running action and left alone.
- Graceful fallback: if the invoke response has no `log_id` (older herdr), behave exactly as before (dispatch-and-exit).

No change to the success path's UX — a succeeding action still closes the overlay silently.

## Test plan

Verified with stubbed `herdr`/`fzf` (no TTY):

- [x] `bash -n` passes on both bash 5.3 and macOS system bash 3.2
- [x] Action reports `status=failed`, exit 127 → `die()` prints the action's stderr, script exits 1
- [x] Action reports `status=succeeded` → clean exit 0, no output
- [x] Invoke response without `log_id` (older herdr) → graceful exit 0
- [x] Manually: a real invoke of a working action returns `succeeded`/exit 0 and the overlay closes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx4xvmvCjYzntCUsGXFQKA